### PR TITLE
use "nobody" command to show only chat

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ func main() {
 	}
 	defer conn.Close()
 	log.Println("client: connected to: ", conn.RemoteAddr())
+	fmt.Fprintln(conn, "nobody")
 
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -29,9 +30,6 @@ func main() {
 		scanner := bufio.NewScanner(conn)
 		for scanner.Scan() {
 			line := strings.TrimSpace(re.ReplaceAllString(scanner.Text(), ""))
-			if !strings.HasPrefix(line, ">>") {
-				continue
-			}
 			fmt.Println(line)
 		}
 	}()


### PR DESCRIPTION
一定の長さを超える行が強制改行されるという仕様になったため、行頭が `>>` かどうかでチャットか否かを判定すると、強制改行以降の部分が抜け落ちてしまいます。

代わりに、接続直後に "nobody" コマンドを送信することによってチャットのみを表示するように改修しました。